### PR TITLE
Update NuGet package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,11 +6,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Abstractions" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.0" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Analyzers" Version="9.0.1" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="9.0.1" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
     <PackageVersion Include="Mtd.Core" Version="9.0.1" />
-    <PackageVersion Include="Mtd.Infrastructure.EFCore" Version="9.0.0" />
-    <PackageVersion Include="Mtd.Stopwatch.Core" Version="9.3.0" />
+    <PackageVersion Include="Mtd.Infrastructure.EFCore" Version="9.1.1" />
+    <PackageVersion Include="Mtd.Stopwatch.Core" Version="9.4.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Updated the following NuGet packages in `Directory.Packages.props`:
- `Microsoft.EntityFrameworkCore.Analyzers` from `9.0.0` to `9.0.1`
- `Microsoft.EntityFrameworkCore.Relational` from `9.0.0` to `9.0.1`
- `Mtd.Infrastructure.EFCore` from `9.0.0` to `9.1.1`
- `Mtd.Stopwatch.Core` from `9.3.0` to `9.4.2`

These updates likely include bug fixes, performance improvements, or new features.